### PR TITLE
Allow use inside zip bundled package

### DIFF
--- a/tests/test_spinners.py
+++ b/tests/test_spinners.py
@@ -9,18 +9,16 @@ Tests for spinners collection.
 
 from __future__ import absolute_import
 
-import codecs
 import json
 from collections import OrderedDict
 
 import pytest
 
 from yaspin.compat import iteritems
-from yaspin.spinners import SPINNERS_PATH, Spinners
+from yaspin.spinners import SPINNERS_DATA, Spinners
 
 
-with codecs.open(SPINNERS_PATH, encoding="utf-8") as f:
-    spinners_dict = OrderedDict(json.load(f))
+spinners_dict = OrderedDict(json.loads(SPINNERS_DATA))
 
 
 test_cases = [

--- a/yaspin/spinners.py
+++ b/yaspin/spinners.py
@@ -8,7 +8,7 @@ A collection of cli spinners.
 """
 
 import codecs
-import os
+import pkgutil
 from collections import namedtuple
 
 try:
@@ -18,12 +18,11 @@ except ImportError:
 
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
-SPINNERS_PATH = os.path.join(THIS_DIR, "data/spinners.json")
+SPINNERS_DATA = pkgutil.get_data(__package__, "data/spinners.json").decode("utf-8")
 
 
 def _hook(dct):
     return namedtuple("Spinner", dct.keys())(*dct.values())
 
 
-with codecs.open(SPINNERS_PATH, encoding="utf-8") as f:
-    Spinners = json.load(f, object_hook=_hook)
+Spinners = json.loads(SPINNERS_DATA, object_hook=_hook)

--- a/yaspin/spinners.py
+++ b/yaspin/spinners.py
@@ -17,7 +17,6 @@ except ImportError:
     import json
 
 
-THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 SPINNERS_DATA = pkgutil.get_data(__package__, "data/spinners.json").decode("utf-8")
 
 


### PR DESCRIPTION
It is very common to bundle a self-contained CLI app into a zip ball, then execute it by `python mycli.zip` or `PYTHONPATH=mycli.zip python -m mycli`. But the json data file is not available inside a zip dir.

Use pkgutil to allow use inside a bundled zip(egg) package.