### PR TITLE
Make write() behave more like print()

### DIFF
--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -104,6 +104,32 @@ def test_write(capsys, text):
         assert out[:-1] == text
 
 
+def test_write_with_non_str_object(capsys):
+    obj = 23
+    sp = yaspin()
+    sp.write(obj)
+
+    out, _ = capsys.readouterr()
+    # cleans stdout from _clear_line and \r
+    out = out.replace("\r\033[K", "")
+
+    assert out == str(obj) + "\n"
+
+
+def test_write_with_multiple_args(capsys):
+    args = ("Hello World,", "this is test no", 23)
+    sp = yaspin()
+    sp.write(*args)
+
+    out, _ = capsys.readouterr()
+    # cleans stdout from _clear_line and \r
+    out = out.replace("\r\033[K", "")
+
+    expected_result = " ".join(str(arg) for arg in args) + "\n"
+
+    assert out == expected_result
+
+
 def test_hide_show(capsys, text, request):
     # Setup
     sp = yaspin()

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -19,7 +19,7 @@ import time
 from .base_spinner import default_spinner
 from .compat import PY2, basestring, builtin_str, bytes, iteritems, str
 from .constants import COLOR_ATTRS, COLOR_MAP, ENCODING, SPINNER_ATTRS
-from .helpers import to_unicode
+from .helpers import to_unicode, to_printable_text
 from .termcolor import colored
 
 
@@ -273,21 +273,15 @@ class Yaspin(object):
                 sys.stdout.write("\r")
                 self._clear_line()
 
-    def write(self, text):
+    def write(self, *args):
         """Write text in the terminal without breaking the spinner."""
         # similar to tqdm.write()
         # https://pypi.python.org/pypi/tqdm#writing-messages
+        _text = ' '.join([to_printable_text(text) for text in args])
+
         with self._stdout_lock:
             sys.stdout.write("\r")
             self._clear_line()
-
-            _text = to_unicode(text)
-            if PY2:
-                _text = _text.encode(ENCODING)
-
-            # Ensure output is bytes for Py2 and Unicode for Py3
-            assert isinstance(_text, builtin_str)
-
             sys.stdout.write("{0}\n".format(_text))
 
     def ok(self, text="OK"):

--- a/yaspin/helpers.py
+++ b/yaspin/helpers.py
@@ -9,7 +9,7 @@ Helper functions.
 
 from __future__ import absolute_import
 
-from .compat import bytes
+from .compat import PY2, builtin_str, bytes, str
 from .constants import ENCODING
 
 
@@ -17,3 +17,14 @@ def to_unicode(text_type, encoding=ENCODING):
     if isinstance(text_type, bytes):
         return text_type.decode(encoding)
     return text_type
+
+
+def to_printable_text(obj):
+    obj = to_unicode(obj)
+    if not isinstance(obj, builtin_str):
+        obj = str(obj)
+
+    if PY2 and isinstance(obj, str):
+        obj = obj.encode(ENCODING)
+
+    return obj


### PR DESCRIPTION
write() now supports printing multiple args, e.g. write("foo", "bar")
and also converts objects that are not a string to their string
representation.

Fixes #34
---
I opted for using `str()` instead of `repr()` for creating the text representation of an object, as this apparently is what the python print() is doing, too.