### PR TITLE
Remove unnecessary assignment of 'sp' and remove unused import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,4 +102,5 @@ travis-setup:
 	pip install pytest~=3.6.3
 	pip install pytest-xdist~=1.22.2
 	pip install pytest-cov~=2.5.1
+	pip install pyyaml==5.1.2  # python-coveralls dep; recently dropped py34 support
 	pip install python-coveralls~=2.9.1

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -452,9 +452,6 @@ class Yaspin(object):
 
     @staticmethod
     def _set_spinner(spinner):
-        if not spinner:
-            sp = default_spinner
-
         if hasattr(spinner, "frames") and hasattr(spinner, "interval"):
             if not spinner.frames or not spinner.interval:
                 sp = default_spinner

--- a/yaspin/spinners.py
+++ b/yaspin/spinners.py
@@ -7,7 +7,6 @@ yaspin.spinners
 A collection of cli spinners.
 """
 
-import codecs
 import pkgutil
 from collections import namedtuple
 


### PR DESCRIPTION
The if statement 'if not spinner' is unnecessary as 'sp' will always be redefined before it's value is returned
Remove unused import of 'codecs'