### PR TITLE
Add hidden() to hide spinner in with-block

### DIFF
--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -12,6 +12,7 @@ A lightweight terminal spinner.
 
 from __future__ import absolute_import
 
+import contextlib
 import functools
 import itertools
 import signal
@@ -80,6 +81,7 @@ class Yaspin(object):
         self._spin_thread = None
         self._last_frame = None
         self._stdout_lock = threading.Lock()
+        self._hidden_level = 0
 
         # Signals
 
@@ -262,6 +264,19 @@ class Yaspin(object):
                 # flush the stdout buffer so the current line
                 # can be rewritten to
                 sys.stdout.flush()
+
+    @contextlib.contextmanager
+    def hidden(self):
+        """Hide the spinner within a block, can be nested"""
+        if self._hidden_level == 0:
+            self.hide()
+        self._hidden_level += 1
+
+        yield
+
+        self._hidden_level -= 1
+        if self._hidden_level == 0:
+            self.show()
 
     def show(self):
         """Show the hidden spinner."""


### PR DESCRIPTION
With hidden() the spinner can be hidden in a with-block. This allows us
to write the following code:

    sp.hide()
    call_cli_menu()
    sp.unhide()

as follows:

    with sp.hidden():
        call_cli_menu()

hidden() can be nested, therefore the following works:

    with sp.hidden():
        # generating some output
        ...
        with sp.hidden():
            # generating more output
            ...