### PR TITLE
Fix hidden context manager exception handling

### DIFF
--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -232,3 +232,22 @@ def test_spinner_nested_hiding_with_context_manager(capsys):
     out, _ = capsys.readouterr()
     out = out.replace("\r\033[K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
+
+
+def test_spinner_nested_hiding_with_context_manager_and_exception(capsys):
+    sp = yaspin(text="foo")
+    sp.start()
+
+    try:
+        with sp.hidden():
+            raise ValueError()
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected a ValueError, something has eaten the exception"
+
+    # make sure spinner is unhidden again
+    assert sp._hidden_level == 0
+    assert not sp._hide_spin.is_set()
+
+    sp.stop()

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -234,7 +234,7 @@ def test_spinner_nested_hiding_with_context_manager(capsys):
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
-def test_spinner_nested_hiding_with_context_manager_and_exception(capsys):
+def test_spinner_hiding_with_context_manager_and_exception():
     sp = yaspin(text="foo")
     sp.start()
 

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -272,11 +272,12 @@ class Yaspin(object):
             self.hide()
         self._hidden_level += 1
 
-        yield
-
-        self._hidden_level -= 1
-        if self._hidden_level == 0:
-            self.show()
+        try:
+            yield
+        finally:
+            self._hidden_level -= 1
+            if self._hidden_level == 0:
+                self.show()
 
     def show(self):
         """Show the hidden spinner."""


### PR DESCRIPTION
When an exception is raised inside the exception block we need to make
sure that the hidden level/unhide logic is executed regardless.

---
I showed #68 to @hartwork and he asked why I'm not using a try-finally construct. He has a point. ;)