### PR TITLE
Wait of stop event instead of sleep.

### DIFF
--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -352,7 +352,7 @@ class Yaspin(object):
                 sys.stdout.flush()
 
             # Wait
-            time.sleep(self._interval)
+            self._stop_spin.wait(self._interval)
 
     def _compose_color_func(self):
         fn = functools.partial(


### PR DESCRIPTION
In my script one spinner is shown per build step. The first time a step takes a few seconds, and the spinner overhead is negligible. However, the next time steps ends almost instantly, and the spinner overhead of about one interval per spinner, in my case n * 80 ms, which is actually quite irritating. This PR waits on the stop condition instead of sleeping, which makes the spinner finish immediately.