### PR TITLE
Allow write() to print non-string objects

### DIFF
--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -253,3 +253,20 @@ def test_spinner_hiding_with_context_manager_and_exception():
     assert not sp._hide_spin.is_set()
 
     sp.stop()
+
+
+@pytest.mark.parametrize(
+    "obj,obj_str",
+    [
+        ("foo", "foo"),
+        (dict(cat="meow"), "{'cat': 'meow'}"),
+        (23, "23"),
+        (["foo", "bar", "'", 23], """['foo', 'bar', "'", 23]"""),
+    ]
+)
+def test_write_non_str_objects(capsys, obj, obj_str):
+    sp = yaspin()
+    capsys.readouterr()
+    sp.write(obj)
+    out, _ = capsys.readouterr()
+    assert out == "\r\033[K{}\n".format(obj_str)

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -319,9 +319,12 @@ class Yaspin(object):
             sys.stdout.write("\r")
             self._clear_line()
 
-            _text = to_unicode(text)
-            if PY2:
-                _text = _text.encode(ENCODING)
+            if isinstance(text, (builtin_str, str, bytes)):
+                _text = to_unicode(text)
+                if PY2:
+                    _text = _text.encode(ENCODING)
+            else:
+                _text = builtin_str(text)
 
             # Ensure output is bytes for Py2 and Unicode for Py3
             assert isinstance(_text, builtin_str)


### PR DESCRIPTION
Allow write() to print anything that is not a string by converting it
via str(), just like the builtin print() does.

Fixes #34

---

This version does not do any `*args` foo just to behave exactly like print. I have found it useful though to just trow any object I currently have into print and have yaspin printig, whatever that may be.

In PR #37 I took a bit of a different approach for converting the `text` argument to string, but I find it to be more concise this way. If there are plans to drop python2 support somewhen in the future this could also be made a lot simpler.

And, as always, I'm open to discussing this. :)