### PR TITLE
Use `poetry_core` as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,5 @@ pytest-sugar = "^0.9"
 "Bug Tracker" = "https://github.com/pavdmyt/yaspin/issues"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Closes: #107 

According to https://python-poetry.org/docs/pyproject/#poetry-and-pep-517

> If your `pyproject.toml` file still references `poetry` directly as a build backend,
> you should update it to reference poetry_core instead.