### PR TITLE
Fix timer round-up behaviour

### DIFF
--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -47,6 +47,30 @@ def test_timer_in_progress():
     assert re.search(r"\(\d+:\d{2}:\d{2}.\d{2}\)", sp._last_frame) is not None
 
 
+def test_timer_rounding_down():
+    sp = yaspin(timer=True)
+    sp.start()
+    sp.stop()
+
+    sp._stop_time = sp._start_time + 0.994
+
+    sp._freeze("")
+
+    assert "(0:00:00.99)" in sp._last_frame
+
+
+def test_timer_rounding_up():
+    sp = yaspin(timer=True)
+    sp.start()
+    sp.stop()
+
+    sp._stop_time = sp._start_time + 0.996
+
+    sp._freeze("")
+
+    assert "(0:00:01.00)" in sp._last_frame
+
+
 def test_timer_finished():
     sp = yaspin(timer=True)
     sp.start()

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -402,9 +402,9 @@ class Yaspin(object):  # pylint: disable=useless-object-inheritance,too-many-ins
             frame, text = text, frame
 
         if self._timer:
-            sec, fsec = divmod(self.elapsed_time, 1)
+            sec, fsec = divmod(round(100*self.elapsed_time), 100)
             text += " ({}.{:02.0f})".format(
-                datetime.timedelta(seconds=sec), 100 * fsec
+                datetime.timedelta(seconds=sec), fsec
             )
 
         # Mode


### PR DESCRIPTION
The timer feature (#99) introduced a bug in the formatting of fractional seconds when the fractional part is >= 0.995:

```python
>>> with yaspin(timer=True) as sp:
...     time.sleep(0.995)
...     sp.ok()
OK  (0:00:00.100)
```

This PR fixes it, making the rounding up work correctly:

```python
>>> with yaspin(timer=True) as sp:
...     time.sleep(0.995)
...     sp.ok()
OK  (0:00:01.00)
```