### PR TITLE
Prevent LICENSE, README.rst, and HISTORY.rst from being installed in site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,10 @@ homepage = "https://github.com/pavdmyt/yaspin"
 repository = "https://github.com/pavdmyt/yaspin"
 documentation = "https://github.com/pavdmyt/yaspin/blob/master/README.rst"
 keywords = ["spinner", "console", "terminal", "loader", "indicator"]
-packages = [
-    { include = "yaspin" },
-    { include = "tests", format = "sdist" },
-    { include = "examples", format = "sdist" },
-]
 include = [
-    "README.rst",
-    "HISTORY.rst",
-    "LICENSE",
-    "yaspin/data/spinners.json",
+    { path = "tests", format = "sdist" },
+    { path = "examples", format = "sdist" },
+    { path = "HISTORY.rst", format = "sdist"}
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Putting LICENSE, README.rst, and HISTORY.rst in the `include` section of pyproject.toml will cause those files to be included in the final wheel and result in them ending up in `site-packages` when yaspin is installed.

```
$ ls ~/Library/Python/3.9/lib/python/site-packages/
HISTORY.rst                 pkg_resources
LICENSE                     setuptools
README.rst                  setuptools-57.0.0.dist-info
__pycache__                 termcolor-1.1.0.dist-info
_distutils_hack             termcolor.py
distutils-precedence.pth    yaspin
pip                         yaspin-2.0.0.dist-info
pip-21.1.2.dist-info
$ cat ~/Library/Python/3.9/lib/python/site-packages/README.rst
|Logo|

=====================================================================
``yaspin``: **Y**\ et **A**\ nother Terminal **Spin**\ ner for Python
=====================================================================

|Build Status| |Coverage| |Codacy| |pyup| |black-fmt|

|pypi| |Versions| |Wheel| |Examples|

|DownloadsTot| |DownloadsW|


``Yaspin`` provides a full-featured terminal spinner to show the progress during long-hanging operations.
<snip>
```

Poetry automatically includes LICENSE and README.rst in the sdist and wheel so they do not need to be specified. Also poetry will automatically pick up all files in a package so `yaspin/data/spinners.json` does not need to be specified either.

HISTORY.rst does need to be explicitly included, but should only be in the sdist.

See https://github.com/python-poetry/poetry/issues/2015#issuecomment-728998784 for details