### PR TITLE
Fix ANSI control sequences in Jupyter notebooks

### DIFF
--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -81,7 +81,7 @@ def test_write(capsys, text):
 
     out, _ = capsys.readouterr()
     # cleans stdout from _clear_line and \r
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
 
     assert isinstance(out, (str, bytes))
     assert out[-1] == "\n"
@@ -110,7 +110,7 @@ def test_hide_show(capsys, text, request):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared with the hide method
-    assert out[-4:] == "\r\033[K"
+    assert out[-5:] == "\r\033[0K"
 
     # ``\n`` is required to flush stdout during
     # the hidden state of the spinner
@@ -118,7 +118,7 @@ def test_hide_show(capsys, text, request):
     out, _ = capsys.readouterr()
 
     # cleans stdout from _clear_line and \r
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
 
     assert isinstance(out, (str, bytes))
     assert out[-1] == "\n"
@@ -132,7 +132,7 @@ def test_hide_show(capsys, text, request):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared before resuming the spinner
-    assert out[:4] == "\r\033[K"
+    assert out[:5] == "\r\033[0K"
 
 
 def test_spinner_write_race_condition(capsys):
@@ -174,7 +174,7 @@ def test_spinner_hiding_with_context_manager(capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -202,7 +202,7 @@ def test_spinner_nested_hiding_with_context_manager(capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -239,4 +239,4 @@ def test_write_non_str_objects(capsys, obj, obj_str):
     capsys.readouterr()
     sp.write(obj)
     out, _ = capsys.readouterr()
-    assert out == "\r\033[K{}\n".format(obj_str)
+    assert out == "\r\033[0K{}\n".format(obj_str)

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -249,7 +249,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             self._stop_spin.set()
             self._spin_thread.join()
 
-        sys.stdout.write("\r")
         self._clear_line()
         self._show_cursor()
 
@@ -261,9 +260,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             with self._stdout_lock:
                 # set the hidden spinner flag
                 self._hide_spin.set()
-
-                # clear the current line
-                sys.stdout.write("\r")
                 self._clear_line()
 
                 # flush the stdout buffer so the current line
@@ -294,7 +290,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
                 self._hide_spin.clear()
 
                 # clear the current line so the spinner is not appended to it
-                sys.stdout.write("\r")
                 self._clear_line()
 
     def write(self, text):
@@ -302,7 +297,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         # similar to tqdm.write()
         # https://pypi.python.org/pypi/tqdm#writing-messages
         with self._stdout_lock:
-            sys.stdout.write("\r")
             self._clear_line()
 
             if isinstance(text, (str, bytes)):

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -541,5 +541,4 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
-        if sys.stdout.isatty():
-            sys.stdout.write("\033[K")
+        sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -354,8 +354,8 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
             # Write
             with self._stdout_lock:
-                sys.stdout.write(out)
                 self._clear_line()
+                sys.stdout.write(out)
                 sys.stdout.flush()
 
             # Wait
@@ -542,4 +542,5 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
+        sys.stdout.write("\r")
         sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -313,7 +313,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            fill = min(0, len(self._text) - len(_text))
+            fill = max(0, len(self._text) - len(_text))
             sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
 
     def ok(self, text="OK"):

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -307,8 +307,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            fill = max(0, len(self._text) - len(_text) + 2)
-            sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
+            sys.stdout.write("{0}\n".format(_text))
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -225,9 +225,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         if self._sigmap:
             self._register_signal_handlers()
 
-        if sys.stdout.isatty():
-            self._hide_cursor()
-
+        self._hide_cursor()
         self._start_time = time.time()
         self._stop_time = None  # Reset value to properly calculate subsequent spinner starts (if any)  # pylint: disable=line-too-long
         self._stop_spin = threading.Event()
@@ -253,9 +251,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
         sys.stdout.write("\r")
         self._clear_line()
-
-        if sys.stdout.isatty():
-            self._show_cursor()
+        self._show_cursor()
 
     def hide(self):
         """Hide the spinner to allow for custom writing to the terminal."""
@@ -533,14 +529,17 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _hide_cursor():
-        sys.stdout.write("\033[?25l")
-        sys.stdout.flush()
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[?25l")
+            sys.stdout.flush()
 
     @staticmethod
     def _show_cursor():
-        sys.stdout.write("\033[?25h")
-        sys.stdout.flush()
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[?25h")
+            sys.stdout.flush()
 
     @staticmethod
     def _clear_line():
-        sys.stdout.write("\033[K")
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -313,7 +313,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            fill = max(0, len(self._text) - len(_text))
+            fill = max(0, len(self._text) - len(_text) + 2)
             sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
 
     def ok(self, text="OK"):

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -313,7 +313,8 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            sys.stdout.write("{0}\n".format(_text))
+            fill = min(0, len(self._text) - len(_text))
+            sys.stdout.write("{0}{1}\n".format(" " * fill, _text))
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""
@@ -541,5 +542,4 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
-        sys.stdout.write("\033[0F")
         sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -541,4 +541,5 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
+        sys.stdout.write("\033[0F")
         sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -314,7 +314,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             assert isinstance(_text, str)
 
             fill = min(0, len(self._text) - len(_text))
-            sys.stdout.write("{0}{1}\n".format(" " * fill, _text))
+            sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""


### PR DESCRIPTION
I suggest this fix for https://github.com/pavdmyt/yaspin/issues/176. 
1. it checks if stdout is a TTY before printing [private](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences) ANSI control sequences (DECTCEM 1&2)
2. I also corrected the EL sequence, which was missing the 0 for its canonical form (`^[K` is a special case of `^[0K`)
3. I added a CR before the EL (which was already partly the case, but cluttered around the code).
4. some clean-up in the code calling the foregoing functions

Other control sequences seem to work fine in Jupyter. Tests:
- Jupyter notebook
![Peek 2022-05-05 10-31](https://user-images.githubusercontent.com/17453878/166888103-8fcc7569-be64-4a4b-9033-0216144e5818.gif)
- Terminal
![Peek 2022-05-05 10-32](https://user-images.githubusercontent.com/17453878/166888170-35e0d59e-afd9-4235-adf8-c1c6b5829f67.gif)


