### PR TITLE
Use alternative to ANSI control sequences in Jupyter notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ pypi_pwd := $(shell grep password ~/.pypirc | awk -F"= " '{ print $$2 }')
 
 flake:
 	@echo "$(OK_COLOR)==> Linting code ...$(NO_COLOR)"
-	@poetry run flake8 --ignore=F821,E501 .
+	@poetry run flake8 --ignore=F821,E501,W503 .
 
 lint:
 	@echo "$(OK_COLOR)==> Linting code ...$(NO_COLOR)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,8 +95,8 @@ def reversal(request):
     return request.param
 
 
-@pytest.fixture(scope="session", params=[True, False], ids=["terminal", "Jupyter"])
-def isatty(request):
+@pytest.fixture(scope="session", params=[True, False], ids=["terminal", "jupyter"])
+def isatty_fixture(request):
     return request.param
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,11 @@ def reversal(request):
     return request.param
 
 
+@pytest.fixture(scope="session", params=[True, False], ids=["terminal", "Jupyter"])
+def isatty(request):
+    return request.param
+
+
 def color_id_func(case):
     if isinstance(case, tuple):
         color, _ = case

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,11 @@ def isatty_fixture(request):
     return request.param
 
 
+@pytest.fixture(autouse=True)
+def isatty_true(monkeypatch):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+
 def color_id_func(case):
     if isinstance(case, tuple):
         color, _ = case

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -6,6 +6,7 @@ Test Yaspin attributes magic hidden in __getattr__.
 """
 
 import sys
+
 import pytest
 
 from yaspin import yaspin

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -5,6 +5,7 @@ tests.test_attrs
 Test Yaspin attributes magic hidden in __getattr__.
 """
 
+import sys
 import pytest
 
 from yaspin import yaspin
@@ -19,12 +20,13 @@ def test_set_spinner_by_name(attr_name):
 
 
 # Values for ``color`` argument
-def test_color(color_test_cases):
+def test_color(monkeypatch, color_test_cases):
     color, expected = color_test_cases
     # ``None`` and ``""`` are skipped
     if not color:
         pytest.skip("{0} - unsupported case".format(repr(color)))
 
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin()
 
     if isinstance(expected, Exception):
@@ -37,12 +39,13 @@ def test_color(color_test_cases):
 
 
 # Values for ``on_color`` argument
-def test_on_color(on_color_test_cases):
+def test_on_color(monkeypatch, on_color_test_cases):
     on_color, expected = on_color_test_cases
     # ``None`` and ``""`` are skipped
     if not on_color:
         pytest.skip("{0} - unsupported case".format(repr(on_color)))
 
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin()
 
     if isinstance(expected, Exception):
@@ -60,7 +63,8 @@ def test_on_color(on_color_test_cases):
 @pytest.mark.parametrize(
     "attr", sorted([k for k, v in COLOR_MAP.items() if v == "attrs"])
 )
-def test_attrs(attr):
+def test_attrs(monkeypatch, attr):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin()
     getattr(sp, attr)
     assert sp.attrs == [attr]

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -84,14 +84,14 @@ def test_color_jupyter(monkeypatch):
     assert "\033" not in out
 
 
-def test_write(monkeypatch, capsys, text, isatty):
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty)
+def test_write(monkeypatch, capsys, text, isatty_fixture):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty_fixture)
     sp = yaspin()
     sp.write(text)
 
     out, _ = capsys.readouterr()
     # cleans stdout from _clear_line
-    if isatty:
+    if isatty_fixture:
         out = out.replace("\r\033[K", "")
     else:
         out = out.replace("\r", "")
@@ -114,9 +114,9 @@ def test_show_jupyter(monkeypatch, capsys):
     assert "12345\r" + " " * len("rsw12345") + "\r123" in out
 
 
-def test_hide_show(monkeypatch, capsys, text, request, isatty):
+def test_hide_show(monkeypatch, capsys, text, request, isatty_fixture):
     # Setup
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty_fixture)
     sp = yaspin()
     sp.start()
 
@@ -136,7 +136,7 @@ def test_hide_show(monkeypatch, capsys, text, request, isatty):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared with the hide method
-    if isatty:
+    if isatty_fixture:
         assert out[-4:] == "\r\033[K"
     else:
         assert out[-1:] == "\r"
@@ -147,7 +147,7 @@ def test_hide_show(monkeypatch, capsys, text, request, isatty):
     out, _ = capsys.readouterr()
 
     # cleans stdout from _clear_line
-    if isatty:
+    if isatty_fixture:
         out = out.replace("\r\033[K", "")
     else:
         out = out.replace("\r", "")
@@ -164,7 +164,7 @@ def test_hide_show(monkeypatch, capsys, text, request, isatty):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared before resuming the spinner
-    if isatty:
+    if isatty_fixture:
         assert out[:4] == "\r\033[K"
     else:
         assert out[:1] == "\r"

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -83,7 +83,7 @@ def test_write(monkeypatch, capsys, text):
 
     out, _ = capsys.readouterr()
     # cleans stdout from _clear_line and \r
-    out = out.replace("\r\033[0K", "")
+    out = out.replace("\r\033[K", "")
 
     assert isinstance(out, (str, bytes))
     assert out[-1] == "\n"
@@ -113,7 +113,7 @@ def test_hide_show(monkeypatch, capsys, text, request):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared with the hide method
-    assert out[-5:] == "\r\033[0K"
+    assert out[-4:] == "\r\033[K"
 
     # ``\n`` is required to flush stdout during
     # the hidden state of the spinner
@@ -121,7 +121,7 @@ def test_hide_show(monkeypatch, capsys, text, request):
     out, _ = capsys.readouterr()
 
     # cleans stdout from _clear_line and \r
-    out = out.replace("\r\033[0K", "")
+    out = out.replace("\r\033[K", "")
 
     assert isinstance(out, (str, bytes))
     assert out[-1] == "\n"
@@ -135,7 +135,7 @@ def test_hide_show(monkeypatch, capsys, text, request):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared before resuming the spinner
-    assert out[:5] == "\r\033[0K"
+    assert out[:4] == "\r\033[K"
 
 
 def test_spinner_write_race_condition(capsys):
@@ -178,7 +178,7 @@ def test_spinner_hiding_with_context_manager(monkeypatch, capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[0K", "")
+    out = out.replace("\r\033[K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -207,7 +207,7 @@ def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[0K", "")
+    out = out.replace("\r\033[K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -245,4 +245,4 @@ def test_write_non_str_objects(monkeypatch, capsys, obj, obj_str):
     capsys.readouterr()
     sp.write(obj)
     out, _ = capsys.readouterr()
-    assert out == "\r\033[0K{}\n".format(obj_str)
+    assert out == "\r\033[K{}\n".format(obj_str)

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -45,7 +45,7 @@ def test_repr(text, frames, interval):
 
 
 def test_compose_out_with_color(
-    monkeypatch, color_test_cases, on_color_test_cases, attrs_test_cases
+    color_test_cases, on_color_test_cases, attrs_test_cases
 ):
     color, color_exp = color_test_cases
     on_color, on_color_exp = on_color_test_cases

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -189,10 +189,10 @@ def test_spinner_write_race_condition(capsys):
     assert not re.search(r"aaaa[^\rb]*bbbb", out)
 
 
-def test_spinner_hiding_with_context_manager(monkeypatch, capsys):
+def test_spinner_hiding_with_context_manager(monkeypatch, capsys, isatty_fixture):
     HIDDEN_START = "hidden start"
     HIDDEN_END = "hidden end"
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty_fixture)
     sp = yaspin(text="foo")
     sp.start()
 
@@ -210,14 +210,17 @@ def test_spinner_hiding_with_context_manager(monkeypatch, capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[K", "")
+    if isatty_fixture:
+        out = out.replace("\r\033[K", "")
+    else:
+        out = out.replace("\r", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
-def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys):
+def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys, isatty_fixture):
     HIDDEN_START = "hidden start"
     HIDDEN_END = "hidden end"
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty_fixture)
     sp = yaspin(text="foo")
     sp.start()
 
@@ -239,7 +242,10 @@ def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[K", "")
+    if isatty_fixture:
+        out = out.replace("\r\033[K", "")
+    else:
+        out = out.replace("\r", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -271,10 +277,13 @@ def test_spinner_hiding_with_context_manager_and_exception():
         (["foo", "bar", "'", 23], """['foo', 'bar', "'", 23]"""),
     ],
 )
-def test_write_non_str_objects(monkeypatch, capsys, obj, obj_str):
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+def test_write_non_str_objects(monkeypatch, capsys, obj, obj_str, isatty_fixture):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty_fixture)
     sp = yaspin()
     capsys.readouterr()
     sp.write(obj)
     out, _ = capsys.readouterr()
-    assert out == "\r\033[K{}\n".format(obj_str)
+    if isatty_fixture:
+        assert out == "\r\033[K{}\n".format(obj_str)
+    else:
+        assert out == "\r\r{}\n".format(obj_str)

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -78,7 +78,8 @@ def test_compose_out_with_color(
 
 def test_color_jupyter(monkeypatch):
     monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
-    sp = yaspin(color="red")
+    with pytest.warns(UserWarning):
+        sp = yaspin(color="red")
 
     out = sp._compose_out(frame=u"/")
     assert "\033" not in out

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -211,7 +211,7 @@ def test_spinner_hiding_with_context_manager(monkeypatch, capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[0K", "")
+    out = out.replace("\r\033[K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -240,7 +240,7 @@ def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[0K", "")
+    out = out.replace("\r\033[K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -278,4 +278,4 @@ def test_write_non_str_objects(monkeypatch, capsys, obj, obj_str):
     capsys.readouterr()
     sp.write(obj)
     out, _ = capsys.readouterr()
-    assert out == "\r\033[0K{}\n".format(obj_str)
+    assert out == "\r\033[K{}\n".format(obj_str)

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -45,7 +45,7 @@ def test_repr(text, frames, interval):
 
 
 def test_compose_out_with_color(
-    color_test_cases, on_color_test_cases, attrs_test_cases
+    monkeypatch, color_test_cases, on_color_test_cases, attrs_test_cases
 ):
     color, color_exp = color_test_cases
     on_color, on_color_exp = on_color_test_cases
@@ -65,6 +65,7 @@ def test_compose_out_with_color(
         pytest.skip("{0} - unsupported case".format(items))
 
     # Actual test
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin(color=color, on_color=on_color, attrs=attrs)
     assert sp._color == color
     assert sp._on_color == on_color
@@ -75,7 +76,8 @@ def test_compose_out_with_color(
     assert isinstance(out, str)
 
 
-def test_write(capsys, text):
+def test_write(monkeypatch, capsys, text):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin()
     sp.write(text)
 
@@ -89,8 +91,9 @@ def test_write(capsys, text):
         assert out[:-1] == text
 
 
-def test_hide_show(capsys, text, request):
+def test_hide_show(monkeypatch, capsys, text, request):
     # Setup
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin()
     sp.start()
 
@@ -154,9 +157,10 @@ def test_spinner_write_race_condition(capsys):
     assert not re.search(r"aaaa[^\rb]*bbbb", out)
 
 
-def test_spinner_hiding_with_context_manager(capsys):
+def test_spinner_hiding_with_context_manager(monkeypatch, capsys):
     HIDDEN_START = "hidden start"
     HIDDEN_END = "hidden end"
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin(text="foo")
     sp.start()
 
@@ -178,9 +182,10 @@ def test_spinner_hiding_with_context_manager(capsys):
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
-def test_spinner_nested_hiding_with_context_manager(capsys):
+def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys):
     HIDDEN_START = "hidden start"
     HIDDEN_END = "hidden end"
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin(text="foo")
     sp.start()
 
@@ -234,7 +239,8 @@ def test_spinner_hiding_with_context_manager_and_exception():
         (["foo", "bar", "'", 23], """['foo', 'bar', "'", 23]"""),
     ],
 )
-def test_write_non_str_objects(capsys, obj, obj_str):
+def test_write_non_str_objects(monkeypatch, capsys, obj, obj_str):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin()
     capsys.readouterr()
     sp.write(obj)

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -65,7 +65,6 @@ def test_compose_out_with_color(
         pytest.skip("{0} - unsupported case".format(items))
 
     # Actual test
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     sp = yaspin(color=color, on_color=on_color, attrs=attrs)
     assert sp._color == color
     assert sp._on_color == on_color

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -81,7 +81,7 @@ def test_write(capsys, text):
 
     out, _ = capsys.readouterr()
     # cleans stdout from _clear_line and \r
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
 
     assert isinstance(out, (str, bytes))
     assert out[-1] == "\n"
@@ -110,7 +110,7 @@ def test_hide_show(capsys, text, request):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared with the hide method
-    assert out[-4:] == "\r\033[K"
+    assert out[-5:] == "\r\033[0K"
 
     # ``\n`` is required to flush stdout during
     # the hidden state of the spinner
@@ -118,7 +118,7 @@ def test_hide_show(capsys, text, request):
     out, _ = capsys.readouterr()
 
     # cleans stdout from _clear_line and \r
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
 
     assert isinstance(out, (str, bytes))
     assert out[-1] == "\n"
@@ -132,7 +132,7 @@ def test_hide_show(capsys, text, request):
     out, _ = capsys.readouterr()
 
     # ensure that text was cleared before resuming the spinner
-    assert out[:4] == "\r\033[K"
+    assert out[:5] == "\r\033[0K"
 
 
 def test_spinner_write_race_condition(capsys):
@@ -174,7 +174,7 @@ def test_spinner_hiding_with_context_manager(capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -202,7 +202,7 @@ def test_spinner_nested_hiding_with_context_manager(capsys):
 
     # make sure no spinner text was printed while the spinner was hidden
     out, _ = capsys.readouterr()
-    out = out.replace("\r\033[K", "")
+    out = out.replace("\r\033[0K", "")
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
@@ -239,4 +239,4 @@ def test_write_non_str_objects(capsys, obj, obj_str):
     capsys.readouterr()
     sp.write(obj)
     out, _ = capsys.readouterr()
-    assert out == "\r\033[K{}\n".format(obj_str)
+    assert out == "\r\033[0K{}\n".format(obj_str)

--- a/tests/test_in_out.py
+++ b/tests/test_in_out.py
@@ -217,7 +217,9 @@ def test_spinner_hiding_with_context_manager(monkeypatch, capsys, isatty_fixture
     assert "{}\n{}".format(HIDDEN_START, HIDDEN_END) in out
 
 
-def test_spinner_nested_hiding_with_context_manager(monkeypatch, capsys, isatty_fixture):
+def test_spinner_nested_hiding_with_context_manager(
+    monkeypatch, capsys, isatty_fixture
+):
     HIDDEN_START = "hidden start"
     HIDDEN_END = "hidden end"
     monkeypatch.setattr(sys.stdout, "isatty", lambda: isatty_fixture)

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -249,7 +249,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             self._stop_spin.set()
             self._spin_thread.join()
 
-        sys.stdout.write("\r")
         self._clear_line()
         self._show_cursor()
 
@@ -261,9 +260,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             with self._stdout_lock:
                 # set the hidden spinner flag
                 self._hide_spin.set()
-
-                # clear the current line
-                sys.stdout.write("\r")
                 self._clear_line()
 
                 # flush the stdout buffer so the current line
@@ -294,7 +290,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
                 self._hide_spin.clear()
 
                 # clear the current line so the spinner is not appended to it
-                sys.stdout.write("\r")
                 self._clear_line()
 
     def write(self, text):
@@ -302,7 +297,6 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         # similar to tqdm.write()
         # https://pypi.python.org/pypi/tqdm#writing-messages
         with self._stdout_lock:
-            sys.stdout.write("\r")
             self._clear_line()
 
             if isinstance(text, (str, bytes)):

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -541,5 +541,4 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
-        if sys.stdout.isatty():
-            sys.stdout.write("\033[K")
+        sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -354,8 +354,8 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
             # Write
             with self._stdout_lock:
-                sys.stdout.write(out)
                 self._clear_line()
+                sys.stdout.write(out)
                 sys.stdout.flush()
 
             # Wait
@@ -542,4 +542,5 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
+        sys.stdout.write("\r")
         sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -313,7 +313,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            fill = min(0, len(self._text) - len(_text))
+            fill = max(0, len(self._text) - len(_text))
             sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
 
     def ok(self, text="OK"):

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -307,8 +307,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            fill = max(0, len(self._text) - len(_text) + 2)
-            sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
+            sys.stdout.write("{0}\n".format(_text))
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -225,9 +225,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         if self._sigmap:
             self._register_signal_handlers()
 
-        if sys.stdout.isatty():
-            self._hide_cursor()
-
+        self._hide_cursor()
         self._start_time = time.time()
         self._stop_time = None  # Reset value to properly calculate subsequent spinner starts (if any)  # pylint: disable=line-too-long
         self._stop_spin = threading.Event()
@@ -253,9 +251,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
         sys.stdout.write("\r")
         self._clear_line()
-
-        if sys.stdout.isatty():
-            self._show_cursor()
+        self._show_cursor()
 
     def hide(self):
         """Hide the spinner to allow for custom writing to the terminal."""
@@ -533,14 +529,17 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _hide_cursor():
-        sys.stdout.write("\033[?25l")
-        sys.stdout.flush()
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[?25l")
+            sys.stdout.flush()
 
     @staticmethod
     def _show_cursor():
-        sys.stdout.write("\033[?25h")
-        sys.stdout.flush()
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[?25h")
+            sys.stdout.flush()
 
     @staticmethod
     def _clear_line():
-        sys.stdout.write("\033[K")
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -90,8 +90,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         # custom handlers set by ``sigmap`` at the cleanup phase.
         self._dfl_sigmap = {}  # Dict[Signal, SigHandler]
 
-        if (self._color_func is None
-           and (self._color or self._on_color or self._attrs)):
+        if self._color_func is None and (self._color or self._on_color or self._attrs):
             self._warn_color_disabled()
 
     #

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -313,7 +313,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            fill = max(0, len(self._text) - len(_text))
+            fill = max(0, len(self._text) - len(_text) + 2)
             sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
 
     def ok(self, text="OK"):

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -546,7 +546,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
     def _clear_line(self):
         if sys.stdout.isatty():
             # ANSI Control Sequence EL does not work in Jupyter
-            sys.stdout.write("\r\033[0K")
+            sys.stdout.write("\r\033[K")
         else:
             fill = " " * self._cur_line_len
             sys.stdout.write("\r{0}\r".format(fill))

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -313,7 +313,8 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             # Ensure output is Unicode
             assert isinstance(_text, str)
 
-            sys.stdout.write("{0}\n".format(_text))
+            fill = min(0, len(self._text) - len(_text))
+            sys.stdout.write("{0}{1}\n".format(" " * fill, _text))
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""
@@ -541,5 +542,4 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
-        sys.stdout.write("\033[0F")
         sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -361,7 +361,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
     def _compose_color_func(self):
         if not sys.stdout.isatty():
             # ANSI Color Control Sequences are problematic in Jupyter
-            return lambda x: x
+            return None
 
         return functools.partial(
             colored,

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -337,7 +337,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
     @staticmethod
     def _warn_color_disabled():
         warnings.warn(
-            "Color support is disabled, but you requested coloring.",
+            "color, on_color and attrs are not supported when running in jupyter",
             stacklevel=2,
         )
 

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -541,4 +541,5 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
 
     @staticmethod
     def _clear_line():
+        sys.stdout.write("\033[0F")
         sys.stdout.write("\033[0K")

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -314,7 +314,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             assert isinstance(_text, str)
 
             fill = min(0, len(self._text) - len(_text))
-            sys.stdout.write("{0}{1}\n".format(" " * fill, _text))
+            sys.stdout.write("{0}{1}\n".format(_text, " " * fill))
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -75,6 +75,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         self._last_frame = None
         self._stdout_lock = threading.Lock()
         self._hidden_level = 0
+        self._cur_line_len = 0
 
         # Signals
 
@@ -308,6 +309,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
             assert isinstance(_text, str)
 
             sys.stdout.write("{0}\n".format(_text))
+            self._cur_line_len = 0
 
     def ok(self, text="OK"):
         """Set Ok (success) finalizer to a spinner."""
@@ -332,6 +334,7 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
         self.stop()
         with self._stdout_lock:
             sys.stdout.write(self._last_frame)
+            self._cur_line_len = 0
 
     def _spin(self):
         while not self._stop_spin.is_set():
@@ -350,11 +353,16 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
                 self._clear_line()
                 sys.stdout.write(out)
                 sys.stdout.flush()
+                self._cur_line_len = max(self._cur_line_len, len(out))
 
             # Wait
             self._stop_spin.wait(self._interval)
 
     def _compose_color_func(self):
+        if not sys.stdout.isatty():
+            # ANSI Color Control Sequences are problematic in Jupyter
+            return lambda x: x
+
         return functools.partial(
             colored,
             color=self._color,
@@ -524,16 +532,21 @@ class Yaspin:  # pylint: disable=useless-object-inheritance,too-many-instance-at
     @staticmethod
     def _hide_cursor():
         if sys.stdout.isatty():
+            # ANSI Control Sequence DECTCEM 1 does not work in Jupyter
             sys.stdout.write("\033[?25l")
             sys.stdout.flush()
 
     @staticmethod
     def _show_cursor():
         if sys.stdout.isatty():
+            # ANSI Control Sequence DECTCEM 2 does not work in Jupyter
             sys.stdout.write("\033[?25h")
             sys.stdout.flush()
 
-    @staticmethod
-    def _clear_line():
-        sys.stdout.write("\r")
-        sys.stdout.write("\033[0K")
+    def _clear_line(self):
+        if sys.stdout.isatty():
+            # ANSI Control Sequence EL does not work in Jupyter
+            sys.stdout.write("\r\033[0K")
+        else:
+            fill = " " * self._cur_line_len
+            sys.stdout.write("\r{0}\r".format(fill))


### PR DESCRIPTION
Second try of #193 and fixing #176

1. checking if stdout is a TTY to determine if output is a Jupyter cell or a terminal
2. disabled ANSI control sequence [DECTCEM](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences) for Jupyter (anyway there is no cursor)
3. replaced ANSI control sequence EL for Jupyter (where it doesn't erase the line, but just prints three white spaces) with some code that simply overrides the entire line with white spaces
4. added a CR before the EL (which was already partly the case, but cluttered around the code)
5. cleaned up in the code calling the foregoing functions
6. added patching `sys.stdout.isatty` to pretend output is a terminal

Terminal:
![Peek 2022-05-12 13-21](https://user-images.githubusercontent.com/17453878/168063968-1a44f383-614f-4884-b75e-b85123ff922b.gif)

Jupyter:
![Peek 2022-05-12 13-22](https://user-images.githubusercontent.com/17453878/168063998-f77e440e-0885-4673-9429-667bf0ffd303.gif)