### PR TITLE
ellipsis: ensure `shutil.get_terminal_size` called only during Yaspin instantiation

### DIFF
--- a/tests/test_ellipsis.py
+++ b/tests/test_ellipsis.py
@@ -1,4 +1,6 @@
 import shutil
+import time
+from unittest.mock import patch
 
 from yaspin import yaspin
 
@@ -17,3 +19,16 @@ def test_with_ellipsis():
     frame, timer = 2, 10
     max_len = shutil.get_terminal_size().columns - (frame + len(" ") + timer + len(ellipsis))
     assert sp._get_max_text_length(frame, timer) == max_len
+
+
+@patch("shutil.get_terminal_size")
+def test_terminal_size_called_once(mock_get_terminal_size):
+    mock_get_terminal_size.return_value.columns = 80
+    sp = yaspin(ellipsis="...")
+
+    @sp
+    def long_running_function():
+        time.sleep(0.2)
+
+    long_running_function()
+    mock_get_terminal_size.assert_called_once()

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -129,6 +129,7 @@ class Yaspin:  # pylint: disable=too-many-instance-attributes
         self._reversal = reversal
         self._timer = timer
         self._ellipsis = ellipsis
+        self._terminal_width: int = shutil.get_terminal_size().columns
         self._start_time: Optional[float] = None
         self._stop_time: Optional[float] = None
 
@@ -477,12 +478,11 @@ class Yaspin:  # pylint: disable=too-many-instance-attributes
         return out
 
     def _get_max_text_length(self, frame_width: int, timer_width: int) -> int:
-        term_width = shutil.get_terminal_size().columns
         ellipsis_width = len(self._ellipsis)
         # There is always a space between frame and text
         frame_width += 1
 
-        return term_width - frame_width - timer_width - ellipsis_width
+        return self._terminal_width - frame_width - timer_width - ellipsis_width
 
     def _register_signal_handlers(self) -> None:
         # SIGKILL cannot be caught or ignored, and the receiving


### PR DESCRIPTION
It is possible to cache this value to avoid unnecessary calls while rendering each frame. Changing terminal size while yaspin is running is an unlikely (hopefully 😅 ) situation.