### PR TITLE
ellipsis: handle edge case when terminal is too narrow

### DIFF
--- a/tests/test_ellipsis.py
+++ b/tests/test_ellipsis.py
@@ -1,6 +1,9 @@
 import shutil
+import threading
 import time
 from unittest.mock import patch
+
+import pytest
 
 from yaspin import yaspin
 
@@ -32,3 +35,16 @@ def test_terminal_size_called_once(mock_get_terminal_size):
 
     long_running_function()
     mock_get_terminal_size.assert_called_once()
+
+
+@patch("shutil.get_terminal_size")
+def test_raises_when_term_is_too_small(mock_get_terminal_size):
+    mock_get_terminal_size.return_value.columns = 10
+    sp = yaspin(ellipsis="..." * 5)
+
+    with pytest.raises(ValueError):
+        # Some low-level trickery is needed here because Yaspin._compose_out()
+        # is called in a separate thread and the exception is not propagated.
+        # Pytest indicates that by warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
+        sp._stop_spin = threading.Event()
+        sp._spin()

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -459,6 +459,10 @@ class Yaspin:  # pylint: disable=too-many-instance-attributes
 
         # Truncate
         max_text_len = self._get_max_text_length(len(frame), len(timer))
+        if max_text_len < 1:
+            raise ValueError(
+                f"Terminal size {self._terminal_width} is too small to display spinner with the given settings."
+            )
         text = text[:max_text_len] + self._ellipsis if len(text) > max_text_len else text
 
         # Colors


### PR DESCRIPTION
Terminal size should be sufficient to include: `frame_width + timer_width + ellipsis_width`