### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/lint_test_coverage.yml
+++ b/.github/workflows/lint_test_coverage.yml
@@ -48,9 +48,11 @@ jobs:
   mypy:
     needs: lint
     runs-on: ubuntu-24.04
+    env:
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: checkout-code
@@ -81,10 +83,11 @@ jobs:
     env:
       PYTHONHASHSEED: 0
       USING_COVERAGE: '3.12'
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10"]
 
     steps:
       - name: checkout-code

--- a/.github/workflows/lint_test_coverage.yml
+++ b/.github/workflows/lint_test_coverage.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
 
     steps:
       - name: checkout-code
@@ -101,29 +101,29 @@ jobs:
 
       # Normal Python
       - name: install-poetry
-        if: "!contains(matrix.python-version, 'pypy-3.10')"
+        if: "!contains(matrix.python-version, 'pypy-3.11')"
         uses: snok/install-poetry@v1
         with:
           version: 1.8.3
 
       - name: install-dependencies
-        if: "!contains(matrix.python-version, 'pypy-3.10')"
+        if: "!contains(matrix.python-version, 'pypy-3.11')"
         run: |
           poetry install
 
       - name: run-tests
-        if: "!contains(matrix.python-version, 'pypy-3.10')"
+        if: "!contains(matrix.python-version, 'pypy-3.11')"
         run: |
           make test
 
       # PyPy
       - name: install-dependencies
-        if: "contains(matrix.python-version, 'pypy-3.10')"
+        if: "contains(matrix.python-version, 'pypy-3.11')"
         run: |
           pip install termcolor==2.3.0 pytest==8.1.2 pytest-xdist==3.6.1
 
       - name: run-tests
-        if: "contains(matrix.python-version, 'pypy-3.10')"
+        if: "contains(matrix.python-version, 'pypy-3.11')"
         run: |
           py.test -n auto -v
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
The Python 3.14 release candidate is out. 🚀 

The 3.14 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-14-0rc2-and-3-13-7-are-go/102403?u=hugovk):

> ## Call to action
> 
> We **_strongly encourage_** maintainers of third-party Python projects to prepare their projects for 3.14 during this phase, and publish Python 3.14 wheels on PyPI to be ready for the final release of 3.14.0, and to help other projects do their own testing. Any binary wheels built against Python 3.14.0rc1 **_will work_** with future versions of Python 3.14. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

This PR adds 3.14 to the CI and Trove classifiers. The CI also needed the `PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1` env var.

Also replace PyPy 3.10 with 3.11 on the CI, which is the latest version: https://pypy.org/posts/2025/07/pypy-v7320-release.html