### PR TITLE
deps: drop requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,6 @@ bump:
 bump-minor:
 	@poetry version minor
 
-.PHONY: export-requirements
-export-requirements:
-	@poetry export -f requirements.txt --with dev > requirements.txt
-
 .PHONY: semgrep
 semgrep:
 	poetry run semgrep --error --config "p/secrets" --config "p/bandit" --config "p/secrets" .

--- a/README.md
+++ b/README.md
@@ -391,9 +391,6 @@ Install dev dependencies:
 
 ```bash
 poetry install
-
-# if you don't have poetry installed:
-pip install -r requirements.txt
 ```
 
 Lint code:


### PR DESCRIPTION
Poetry doesn't support from the box exporting requirements anymore, and managing this via plugin is somewhat complicated for poetry installation managed by brew.