### PR TITLE
Fixed Spinner frame type hint issue.

### DIFF
--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -97,7 +97,7 @@ def to_unicode(text_type: str | bytes, encoding: str = ENCODING) -> str:
 
 @dataclass
 class Spinner:
-    frames: str | Sequence[str]
+    frames: Sequence[str]
     interval: int
 
 
@@ -803,7 +803,7 @@ class Yaspin:
             uframes = spinner.frames
 
         # TODO (pavdmyt): support any type that implements iterable
-        if isinstance(spinner.frames, list | tuple):
+        if isinstance(spinner.frames, Sequence):
             # Empty ``spinner.frames`` is handled by ``Yaspin._set_spinner``
             if spinner.frames and isinstance(spinner.frames[0], bytes):
                 uframes_seq = [to_unicode(frame) for frame in spinner.frames]


### PR DESCRIPTION
This fixes any type errors raised when passing some list object to `Spinner`.

All tests that aren't skipped pass. 1 unrelated warning.
<details>
<summary>See tests output</summary>

```
================================================================== warnings summary ===================================================================
tests/test_stream.py::test_stream_parameter_with_other_parameters[kwargs1]
  /mnt/c/Users/bodbo/OneDrive/Documents/GitHub/yaspin/yaspin/core.py:172: UserWarning: color, on_color and attrs are not supported when output stream is not a TTY
    self._color = self._set_color(color) if color else color

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== 3034 passed, 1758 skipped, 1 warning in 86.39s (0:01:26) ===============================================
```

</details>

closes #260 