### PR TITLE
feat: support custom timer formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,19 @@ with yaspin(text="elapsed time", timer=True) as sp:
     sp.ok()
 ```
 
+To omit the fractions of a second, pass a format string with one automatic
+replacement field. It receives the elapsed time as a `datetime.timedelta`.
+Use a second field to receive hundredths of a second.
+
+```python
+with yaspin(text="elapsed time", timer=" ({})") as sp:
+    time.sleep(3.1415)
+    sp.ok()
+```
+
+The default `timer=True` format is ` ({}.{:02.0f})`. Custom formats must
+contain one or two automatic replacement fields.
+
 ### Custom streams
 
 By default, yaspin outputs to `sys.stdout`. You can redirect spinner output to any stream using the `stream` parameter:

--- a/examples/timer_spinner.py
+++ b/examples/timer_spinner.py
@@ -10,12 +10,20 @@ import time
 from yaspin import yaspin
 
 
-def main():
+def default_timer():
     with yaspin(text="elapsed time", timer=True) as sp:
-        # Floats are rounded into two decimal digits in timer output
+        # Floats are rounded into two decimal digits in timer output.
+        time.sleep(3.1415)
+        sp.ok()
+
+
+def custom_timer():
+    with yaspin(text="elapsed time", timer=" ({})") as sp:
+        # A custom format can omit fractions of a second.
         time.sleep(3.1415)
         sp.ok()
 
 
 if __name__ == "__main__":
-    main()
+    default_timer()
+    custom_timer()

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -56,6 +56,7 @@ def test_timer_custom_format(timer, expected):
         pytest.param("{0}", id="indexed-field"),
         pytest.param("{elapsed}", id="named-field"),
         pytest.param("{", id="malformed-brace"),
+        pytest.param("{!s:{}<}", id="nested-field"),
         pytest.param("{:02.0f}", id="incompatible-format-spec"),
     ],
 )

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -5,6 +5,8 @@ tests.test_timer
 Test timer feature.
 """
 
+from io import StringIO
+
 import re
 import time
 
@@ -28,6 +30,51 @@ def test_timer_idle():
     sp._freeze("")
 
     assert "(0:00:00.00)" in sp._last_frame
+
+
+@pytest.mark.parametrize(
+    "timer, expected",
+    [
+        pytest.param(" ({})", " (0:00:00)", id="elapsed-time-only"),
+        pytest.param(" [{}.{:02.0f}]", " [0:00:00.00]", id="elapsed-time-and-hundredths"),
+        pytest.param(" {{{}}}", " {0:00:00}", id="escaped-braces"),
+    ],
+)
+def test_timer_custom_format(timer, expected):
+    sp = yaspin(timer=timer)
+    sp._freeze("")
+
+    assert expected in sp._last_frame
+
+
+@pytest.mark.parametrize(
+    "timer",
+    [
+        pytest.param("", id="no-fields"),
+        pytest.param("elapsed", id="literal-only"),
+        pytest.param("{} {} {}", id="three-fields"),
+        pytest.param("{0}", id="indexed-field"),
+        pytest.param("{elapsed}", id="named-field"),
+        pytest.param("{", id="malformed-brace"),
+        pytest.param("{:02.0f}", id="incompatible-format-spec"),
+    ],
+)
+def test_timer_custom_format_validation(timer):
+    with pytest.raises(ValueError, match="timer format"):
+        yaspin(timer=timer)
+
+
+@pytest.mark.parametrize("timer", [pytest.param(0, id="integer"), pytest.param(None, id="none")])
+def test_timer_rejects_non_bool_or_str_value(timer):
+    with pytest.raises(TypeError, match="timer must be a bool or str"):
+        yaspin(timer=timer)
+
+
+def test_custom_timer_format_is_included_in_text_truncation():
+    sp = yaspin(text="abc", timer=" ({})", stream=StringIO())
+    sp._terminal_width = len("* ") + len(" (0:00:00)") + 2
+
+    assert sp._compose_out("*") == "\r* ab (0:00:00)"
 
 
 def test_timer_in_progress():

--- a/yaspin/api.py
+++ b/yaspin/api.py
@@ -35,7 +35,11 @@ def yaspin(*args: Any, **kwargs: Any) -> Yaspin:
             of the text string.
         sigmap (dict, optional): Maps POSIX signals to their respective
             handlers.
-        timer (bool, optional): Prints a timer showing the elapsed time.
+        timer (bool | str, optional): Prints a timer showing the elapsed time.
+            Pass True for the default `` (H:MM:SS.hh)`` format. A custom
+            string must contain one or two automatic replacement fields: the
+            first receives elapsed time as a ``datetime.timedelta`` and the
+            optional second receives hundredths of a second.
         ellipsis (str, optional): Sets a custom ellipsis to signal text
             truncation due to overflow.
         stream (TextIO, optional): Output stream for the spinner. Defaults
@@ -55,6 +59,8 @@ def yaspin(*args: Any, **kwargs: Any) -> Yaspin:
             is specified.
         ValueError: If trying to register handler for SIGKILL signal.
         ValueError: If unsupported ``side`` is specified.
+        ValueError: If ``timer`` has an invalid custom format.
+        TypeError: If ``timer`` is not a bool or str.
 
     Available text colors:
         red, green, yellow, blue, magenta, cyan, white.

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -814,9 +814,12 @@ class Yaspin:
     def _get_format_fields(format_string: str) -> list[str]:
         """Return the replacement field names from a Python format string."""
         fields = []
-        for _, field_name, _, _ in Formatter().parse(format_string):
-            if field_name is not None:
-                fields.append(field_name)
+        for _, field_name, format_spec, _ in Formatter().parse(format_string):
+            if field_name is None:
+                continue
+            if format_spec and ("{" in format_spec or "}" in format_spec):
+                raise ValueError("nested replacement fields are not supported")
+            fields.append(field_name)
         return fields
 
     @staticmethod

--- a/yaspin/core.py
+++ b/yaspin/core.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Generator, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
+from string import Formatter
 from typing import (
     Any,
     cast,
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
 Fn = TypeVar("Fn", bound=Callable[..., Any])
 
 ENCODING: Final[str] = "utf-8"
+DEFAULT_TIMER_FORMAT: Final[str] = " ({}.{:02.0f})"
 
 
 class SafeStreamWrapper:
@@ -153,7 +155,7 @@ class Yaspin:
         reversal: bool = False,
         side: str = "left",
         sigmap: dict[signal.Signals, SignalHandlers] | None = None,
-        timer: bool = False,
+        timer: bool | str = False,
         ellipsis: str = "",
         stream: TextIO | None = None,
         warn_on_closed_stream: bool = False,
@@ -178,7 +180,7 @@ class Yaspin:
         self._text = text
         self._side = self._set_side(side)
         self._reversal = reversal
-        self._timer = timer
+        self._timer = self._set_timer(timer)
         self._ellipsis = ellipsis
         self._terminal_width: int = shutil.get_terminal_size().columns
         self._start_time: float | None = None
@@ -612,11 +614,7 @@ class Yaspin:
         text = str(self._text)
 
         # Timer
-        if self._timer:
-            sec, fsec = divmod(round(100 * self.elapsed_time), 100)
-            timer = f" ({timedelta(seconds=sec)}.{fsec:02.0f})"
-        else:
-            timer = ""
+        timer = self._format_timer()
 
         # Truncate
         max_text_len = self._get_max_text_length(len(frame), len(timer))
@@ -656,6 +654,15 @@ class Yaspin:
         frame_width += 1
 
         return self._terminal_width - frame_width - timer_width - ellipsis_width
+
+    def _format_timer(self) -> str:
+        """Render the elapsed time according to the configured timer format."""
+        if self._timer is False:
+            return ""
+
+        sec, fsec = divmod(round(100 * self.elapsed_time), 100)
+        timer_format = DEFAULT_TIMER_FORMAT if self._timer is True else self._timer
+        return timer_format.format(timedelta(seconds=sec), fsec)
 
     def _register_signal_handlers(self) -> None:
         """
@@ -779,6 +786,38 @@ class Yaspin:
         if side not in ("left", "right"):
             raise ValueError("'{0}': unsupported side value. Use either 'left' or 'right'.")
         return side
+
+    @staticmethod
+    def _set_timer(timer: bool | str) -> bool | str:
+        """Validate a timer setting and return it unchanged."""
+        if isinstance(timer, bool):
+            return timer
+        if not isinstance(timer, str):
+            raise TypeError("timer must be a bool or str")
+
+        try:
+            fields = Yaspin._get_format_fields(timer)
+        except ValueError as exc:
+            raise ValueError("timer format must contain one or two automatic replacement fields") from exc
+
+        if not 1 <= len(fields) <= 2 or any(field_name != "" for field_name in fields):
+            raise ValueError("timer format must contain one or two automatic replacement fields")
+
+        try:
+            timer.format(timedelta(), 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("timer format must be compatible with elapsed time values") from exc
+
+        return timer
+
+    @staticmethod
+    def _get_format_fields(format_string: str) -> list[str]:
+        """Return the replacement field names from a Python format string."""
+        fields = []
+        for _, field_name, _, _ in Formatter().parse(format_string):
+            if field_name is not None:
+                fields.append(field_name)
+        return fields
 
     @staticmethod
     def _set_frames(spinner: Spinner, reversal: bool) -> str | Sequence[str]:


### PR DESCRIPTION
Implements #236 

## Summary

- Allow timer output to use custom format strings with elapsed time and optional hundredths.
- Validate timer types and format fields with clear errors.
- Update documentation, example usage, and timer coverage.

## Testing

- Not run (not requested)